### PR TITLE
Fix missing uuid dependency and package.json type field order

### DIFF
--- a/packages/ai-engine/package.json
+++ b/packages/ai-engine/package.json
@@ -8,9 +8,9 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.mjs"
     }
   },
   "scripts": {

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -8,9 +8,9 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.mjs"
     }
   },
   "scripts": {

--- a/packages/transaction/package.json
+++ b/packages/transaction/package.json
@@ -8,9 +8,9 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.mjs"
     }
   },
   "scripts": {

--- a/packages/voice-interface/package.json
+++ b/packages/voice-interface/package.json
@@ -8,9 +8,9 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.mjs"
     }
   },
   "scripts": {

--- a/packages/web-automation/package.json
+++ b/packages/web-automation/package.json
@@ -21,13 +21,15 @@
     "clean": "rm -rf dist node_modules"
   },
   "dependencies": {
-    "browser-use": "^0.2.1"
+    "browser-use": "^0.2.1",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@arbi/eslint-config": "workspace:*",
     "@arbi/tsconfig": "workspace:*",
     "@types/jest": "^29.5.11",
     "@types/node": "^20.11.5",
+    "@types/uuid": "^9.0.8",
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",

--- a/packages/web-automation/package.json
+++ b/packages/web-automation/package.json
@@ -8,9 +8,9 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.mjs"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Description

This PR fixes the build errors and warnings encountered when running `pnpm dev`:

1. Added missing `uuid` dependency to the `@arbi/web-automation` package
2. Fixed package.json "types" field order in all packages to address the warning:
   ```
   WARN  ▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]
   ```

## Changes Made

- Added `uuid` (^9.0.1) and `@types/uuid` (^9.0.8) to web-automation package dependencies
- Moved the "types" field before "require" and "import" in the exports configuration for all packages:
  - @arbi/ai-engine
  - @arbi/web-automation
  - @arbi/transaction
  - @arbi/voice-interface
  - @arbi/data

## Testing

After applying these changes, the build issues should be resolved. To verify:
1. Run `pnpm install` to install the new dependencies
2. Run `pnpm dev` to start the development server
3. The build errors related to uuid and the warnings about types field should be gone

Fixes #1
