### PR TITLE
Fix repo structure and deploy MVP to Railway

### DIFF
--- a/.railwayignore
+++ b/.railwayignore
@@ -1,0 +1,11 @@
+node_modules
+.git
+.husky
+*.md
+!README.md
+.env
+.env.*
+!.env.example
+*.log
+dist
+apps/web

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: cd apps/api && node dist/index.js

--- a/RAILWAY_DEPLOY.md
+++ b/RAILWAY_DEPLOY.md
@@ -1,0 +1,85 @@
+# Railway Deployment Guide
+
+This guide will help you deploy the Arbi Arbitrage Engine backend to Railway.
+
+## Quick Deploy
+
+1. **Connect to Railway**
+   - Go to [railway.app](https://railway.app)
+   - Create a new project
+   - Connect your GitHub repository
+
+2. **Configuration**
+   Railway will automatically detect the configuration from:
+   - `nixpacks.toml` - Nixpacks build configuration
+   - `railway.toml` - Railway deployment settings
+   - `Procfile` - Fallback process definition
+
+3. **Environment Variables**
+   Set these required environment variables in Railway dashboard:
+
+   **Required:**
+   - `PORT` - Automatically set by Railway (default: 3000)
+   - `NODE_ENV` - Set to "production"
+
+   **Optional (for full functionality):**
+   - `OPENAI_API_KEY` - For AI features
+   - `ELEVENLABS_API_KEY` - For voice interface
+   - `PORCUPINE_ACCESS_KEY` - For wake word detection
+   - `EBAY_APP_ID` - For eBay API integration
+   - Database variables (if using external DB)
+   - Redis variables (if using external cache)
+
+4. **Verify Deployment**
+   - Check the health endpoint: `https://your-app.railway.app/health`
+   - Test API endpoints: `https://your-app.railway.app/api/arbitrage/health`
+
+## Build Process
+
+Railway will:
+1. Install dependencies with `pnpm install --no-frozen-lockfile`
+2. Build all packages with `pnpm build`
+3. Start the API server from `apps/api/dist/index.js`
+
+## Health Checks
+
+- Health check endpoint: `/health`
+- Returns: `{"status": "ok", "timestamp": "..."}`
+- Timeout: 100 seconds
+
+## Restart Policy
+
+- Type: ON_FAILURE
+- Max Retries: 10
+
+## Minimal MVP Deployment
+
+The backend will run in MVP mode without API keys:
+- Uses mock data scouts for arbitrage opportunities
+- All core API endpoints functional
+- Ready to scale with real API integrations
+
+## Troubleshooting
+
+### Build fails
+- Check build logs in Railway dashboard
+- Verify all packages build locally: `pnpm build`
+
+### Server won't start
+- Check environment variables are set
+- Verify PORT is set (Railway sets this automatically)
+- Check logs for missing dependencies
+
+### Health check fails
+- Ensure server is listening on PORT from environment
+- Verify `/health` endpoint is accessible
+- Check server logs for startup errors
+
+## Next Steps
+
+After successful deployment:
+1. Add your API keys for full functionality
+2. Set up database (PostgreSQL recommended)
+3. Configure Redis for caching
+4. Enable CORS for your frontend domain
+5. Set up monitoring and alerts

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,18 @@
+[phases.setup]
+nixPkgs = ["nodejs_18", "pnpm"]
+
+[phases.install]
+cmds = [
+  "pnpm install --no-frozen-lockfile"
+]
+
+[phases.build]
+cmds = [
+  "pnpm build"
+]
+
+[start]
+cmd = "cd apps/api && node dist/index.js"
+
+[variables]
+NODE_ENV = "production"

--- a/railway.toml
+++ b/railway.toml
@@ -6,3 +6,5 @@ buildCommand = "pnpm install --no-frozen-lockfile && pnpm build"
 startCommand = "cd apps/api && node dist/index.js"
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10
+healthcheckPath = "/health"
+healthcheckTimeout = 100


### PR DESCRIPTION
Add comprehensive Railway deployment configuration to enable immediate deployment of the Arbi arbitrage backend API.

Changes:
- Add nixpacks.toml for Railway build configuration
- Update railway.toml with health check settings
- Add Procfile as fallback deployment option
- Create .railwayignore to optimize deployment size
- Add RAILWAY_DEPLOY.md with deployment guide

The backend is now ready to deploy on Railway with:
- Automatic dependency installation via pnpm
- Multi-package monorepo build support
- Health check endpoint at /health
- MVP mode with mock data scouts (no API keys required)
- Restart policy configured for reliability

Deployment command: cd apps/api && node dist/index.js