### PR TITLE
fix: remove cd command from Railway startCommand

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
     "buildCommand": "pnpm install --no-frozen-lockfile && pnpm build"
   },
   "deploy": {
-    "startCommand": "cd apps/api && node dist/index.js",
+    "startCommand": "node apps/api/dist/index.js",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }

--- a/railway.toml
+++ b/railway.toml
@@ -3,6 +3,6 @@ builder = "NIXPACKS"
 buildCommand = "pnpm install --no-frozen-lockfile && pnpm build"
 
 [deploy]
-startCommand = "cd apps/api && node dist/index.js"
+startCommand = "node apps/api/dist/index.js"
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10


### PR DESCRIPTION
The Railway deployment was failing with "The executable cd could not be found"
because cd is a shell built-in and cannot be executed in Docker's exec form.
Since the Dockerfile sets WORKDIR to /app, we can directly reference the file
path without needing to change directories.