### PR TITLE
Fix railway.json start command - remove cd executable dependency

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -5,8 +5,10 @@
     "buildCommand": "pnpm install --no-frozen-lockfile && pnpm build"
   },
   "deploy": {
-    "startCommand": "cd apps/api && node dist/index.js",
+    "startCommand": "node apps/api/dist/index.js",
     "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 10
+    "restartPolicyMaxRetries": 10,
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 100
   }
 }


### PR DESCRIPTION
The railway.json file was still using 'cd apps/api && node dist/index.js' which caused the deployment error. Railway reads railway.json with higher priority than railway.toml.

Changes:
- Update startCommand to 'node apps/api/dist/index.js'
- Add healthcheckPath and healthcheckTimeout to railway.json

This resolves: "The executable 'cd' could not be found" error in Railway deployment.