### PR TITLE
Clarify Google Ads production redirect guidance

### DIFF
--- a/ADS_AUTOMATION_QUICKSTART.md
+++ b/ADS_AUTOMATION_QUICKSTART.md
@@ -1,0 +1,82 @@
+# 🚀 Auto Ads Quickstart
+
+Use this guide to run Arbi locally (or on your preferred host) and automatically create ad campaigns for your marketplace listings.
+
+## Prerequisites
+- Node.js 18+ and pnpm 8+
+- Cloudinary credentials already configured in your `.env` (used for image hosting when creating listings)
+- (Optional) Ad platform credentials for paid campaigns:
+  - **Google Ads**: `GOOGLE_ADS_CLIENT_ID`, `GOOGLE_ADS_CLIENT_SECRET`, `GOOGLE_ADS_DEVELOPER_TOKEN`, `GOOGLE_ADS_CUSTOMER_ID`, `GOOGLE_ADS_REFRESH_TOKEN`
+  - **Facebook/Instagram Ads**: `FACEBOOK_ACCESS_TOKEN`, `FACEBOOK_AD_ACCOUNT_ID`, `FACEBOOK_PAGE_ID`
+  - **TikTok Ads**: `TIKTOK_ACCESS_TOKEN`
+- Landing page base URL (used in ad creatives):
+  - Set `AD_LANDING_BASE_URL` (recommended) or `PUBLIC_URL` to the domain where customers can reach your product pages (e.g., `https://your-domain.com`).
+  - For local testing, use `http://localhost:3000`.
+
+### Google Ads OAuth client (for refresh token)
+Create an OAuth 2.0 client in Google Cloud Console to generate the refresh token that powers Auto Ads:
+
+- **Application type**: Web application
+- **Name**: `arbi (webclient)` (any descriptive name is fine)
+- **Authorized JavaScript origins**: add `https://arbi.creai.dev` (production) and `http://localhost:3000` (local testing)
+- **Authorized redirect URIs**: add `https://developers.google.com/oauthplayground` (use Google OAuth Playground to exchange the auth code for a refresh token)
+
+> ✅ **Production note:** Auto Ads uses the refresh token in a server-to-server flow, so it’s fine to use the OAuth Playground redirect URI even when running in production (`https://arbi.creai.dev`). You don’t need to expose a redirect endpoint from your domain unless you’re building your own OAuth consent experience.
+
+Then in OAuth Playground, click the gear icon → check **Use your own OAuth credentials**, paste your client ID/secret, authorize the Google Ads API scope, and exchange the auth code for a refresh token. Put that token into `GOOGLE_ADS_REFRESH_TOKEN`.
+
+## Run the Arbi API
+1. Install dependencies:
+   ```bash
+   pnpm install
+   ```
+2. Start the API (defaults to port 3000):
+   ```bash
+   pnpm dev:api
+   ```
+   Or start a compiled build:
+   ```bash
+   pnpm build:api && pnpm start:api
+   ```
+
+## Create a Listing with Auto Ads
+Listing a product automatically triggers ad campaign creation (Google/Facebook/TikTok when credentials are present).
+
+```bash
+curl -X POST http://localhost:3000/api/marketplace/list \
+  -H "Content-Type: application/json" \
+  -d '{
+    "opportunityId": "airpods-001",
+    "productTitle": "Apple AirPods Pro (2nd Gen)",
+    "productDescription": "Brand new, sealed.",
+    "productImageUrls": ["https://images.example.com/airpods.jpg"],
+    "supplierPrice": 189.99,
+    "supplierUrl": "https://target.com/sample",
+    "supplierPlatform": "target",
+    "markupPercentage": 30
+  }'
+```
+
+Response includes the marketplace listing plus any ad campaigns that were created. Landing page links in the response use your `AD_LANDING_BASE_URL`/`PUBLIC_URL` setting.
+
+## Fully Automated Flow (Scanning + Listing + Ads)
+Start the autonomous job to find opportunities, list them, and spin up ads without manual work:
+
+```bash
+curl -X POST http://localhost:3000/api/autonomous-control/start-listing \
+  -H "Content-Type: application/json" \
+  -d '{
+    "scanIntervalMinutes": 60,
+    "minScore": 75,
+    "minProfit": 20,
+    "markupPercentage": 30,
+    "maxListingsPerRun": 10
+  }'
+```
+
+## Verify Things Are Running
+- Check system status: `curl http://localhost:3000/api/autonomous-control/status`
+- List active marketplace items: `curl http://localhost:3000/api/marketplace/listings`
+- Confirm landing pages load at: `http://localhost:3000/product/{listingId}` (or your deployed domain)
+
+With ads credentials set, every new listing will automatically receive ad campaigns and ready-to-share landing pages.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ cd apps/api
 node dist/index.js
 ```
 
+### Auto Ads Quickstart
+
+If you want listings to automatically generate Google/Facebook/TikTok campaigns, set a public base URL for product pages and follow the [Auto Ads Quickstart](ADS_AUTOMATION_QUICKSTART.md):
+
+```bash
+export AD_LANDING_BASE_URL="http://localhost:3000" # or your deployed domain
+pnpm dev:api
+```
+
 ### Test It
 
 ```bash

--- a/REPO_OVERVIEW.md
+++ b/REPO_OVERVIEW.md
@@ -1,0 +1,32 @@
+# Repository Overview
+
+This repository contains **Arbi**, an autonomous arbitrage engine built as a pnpm monorepo. Use this guide to quickly locate key components and supporting documentation.
+
+## Code Layout
+- **apps/api** – Express + TypeScript REST API exposing arbitrage endpoints and health checks.
+- **apps/web** – React front-end for customer-facing dashboards.
+- **packages/arbitrage-engine** – Core arbitrage logic including scouts, analyzers, and risk management routines.
+- **packages/ai-engine** – OpenAI Agents SDK integrations that power opportunity analysis and decisioning.
+- **packages/web-automation** – Playwright-based scraping and automation helpers for sourcing opportunities.
+- **packages/voice-interface** – Whisper/ElevenLabs powered voice interaction tooling.
+- **packages/transaction** – Hyperswitch payment processor integration utilities.
+- **packages/data** – Data access layer for PostgreSQL and Redis.
+- **scripts/get-ebay-api-key.ts** – Utility script to automate eBay API key creation.
+
+## Getting Started
+1. Install prerequisites: Node.js 18+ and pnpm 8+.
+2. Install dependencies: `pnpm install`.
+3. Build all packages: `pnpm build`.
+4. Configure environment: copy `.env.example` to `.env` and add your `EBAY_APP_ID`.
+5. Start API server: `cd apps/api && node dist/index.js`.
+
+## Useful References
+- **README.md** – High-level feature overview, revenue model, and REST API examples.
+- **docs/** – Deployment instructions, launch checklists, and Amazon API alternatives.
+- **QUICKSTART_EBAY.md** – Five-minute guide for setting up eBay credentials.
+- **ENHANCEMENT_ROADMAP.md** – Planned ML/RL improvements.
+
+## Notes
+- Default risk controls include per-opportunity, daily, and monthly budget limits.
+- Opportunity scoring uses a 0-100 point system to filter and prioritize trades.
+- The platform’s business model assumes a 25% commission on realized profits.

--- a/apps/api/src/services/adCampaigns.ts
+++ b/apps/api/src/services/adCampaigns.ts
@@ -35,7 +35,7 @@ interface AdCampaign {
 export class AdCampaignManager {
   private readonly baseUrl: string;
 
-  constructor(baseUrl: string = 'https://arbi.creai.dev') {
+  constructor(baseUrl: string = process.env.AD_LANDING_BASE_URL || process.env.PUBLIC_URL || 'https://arbi.creai.dev') {
     this.baseUrl = baseUrl;
   }
 


### PR DESCRIPTION
## Summary
- clarify that OAuth Playground remains a valid redirect URI for Auto Ads in production
- note that a domain-hosted redirect is only needed if building a custom consent flow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930e47a4334832ea3478809a6a2cf81)