### PR TITLE
Fix: Set correct output directory for Angular landing page

### DIFF
--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,4 +1,6 @@
 {
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
   "rewrites": [
     {
       "source": "/product/:listingId",


### PR DESCRIPTION
- Added outputDirectory: dist to vercel.json
- Angular 18 outputs to ./dist directly (not dist/browser)
- Added buildCommand for clarity
- Fixes Vercel deployment error: No Output Directory named 'browser' found