### PR TITLE
Profit-first guardrails + out-of-stock ad protection

### DIFF
--- a/apps/api/src/jobs/autonomousEngine.ts
+++ b/apps/api/src/jobs/autonomousEngine.ts
@@ -26,6 +26,7 @@ import {
   CampaignConfig,
 } from '../services/google-ads/campaignAutomation';
 import { runOptimizationPass } from '../services/google-ads/campaignOptimizer';
+import { syncAdsToStock } from '../services/google-ads/stockSync';
 import { sourceTrendingFromCJ } from '../services/cjSourcing';
 import { sourceTrendingFromAmazon, isAmazonSourcingConfigured } from '../services/amazonSourcing';
 import { getAutonomousSettings } from '../services/autonomousSettings';
@@ -118,6 +119,14 @@ async function cycle(): Promise<void> {
     } catch (e: any) {
       logger.error('🤖 OPTIMIZE error:', e?.message || e);
     }
+  }
+
+  // 4) Protect spend: pause ads for anything that's gone out of stock.
+  try {
+    const sg = await syncAdsToStock();
+    if (sg.paused.length) logger.info(`🤖 STOCK: paused ${sg.paused.length} out-of-stock campaign(s)`);
+  } catch (e: any) {
+    logger.error('🤖 STOCK error:', e?.message || e);
   }
 }
 

--- a/apps/api/src/routes/google-ads.ts
+++ b/apps/api/src/routes/google-ads.ts
@@ -20,6 +20,7 @@ import { isConfigured as isVideoConfigured, generateProductVideo } from '../serv
 import { uploadVideoToYouTube } from '../services/google-ads/youtubeUpload';
 import { ensureConversionAction, conversionSendTo } from '../services/google-ads/googleAdsConversions';
 import { runOptimizationPass } from '../services/google-ads/campaignOptimizer';
+import { syncAdsToStock } from '../services/google-ads/stockSync';
 
 const router = Router();
 
@@ -481,6 +482,18 @@ router.get('/conversions/setup', async (_req: Request, res: Response, next: Next
 router.post('/optimize', async (_req: Request, res: Response, next: NextFunction) => {
   try {
     res.json({ success: true, ...(await runOptimizationPass()) });
+  } catch (error: any) {
+    next(error);
+  }
+});
+
+/**
+ * POST /api/google-ads/stock-sync — pause ads for out-of-stock products
+ * (don't pay for clicks on things you can't ship). Only pauses, never enables.
+ */
+router.post('/stock-sync', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    res.json({ success: true, ...(await syncAdsToStock()) });
   } catch (error: any) {
     next(error);
   }

--- a/apps/api/src/routes/public-product.ts
+++ b/apps/api/src/routes/public-product.ts
@@ -13,7 +13,7 @@
 
 import { Router, Request, Response } from 'express';
 import Stripe from 'stripe';
-import { getListings } from './marketplace';
+import { getListings, getListing } from './marketplace';
 import { googleAdsGlobalTagHtml, googleAdsConversionEventHtml } from '../services/google-ads/googleAdsConversions';
 
 const router = Router();
@@ -195,10 +195,17 @@ router.get('/product/:listingId/success', async (req: Request, res: Response) =>
     const session = await stripe.checkout.sessions.retrieve(session_id as string);
 
     if (session.payment_status === 'paid') {
-      // TODO: Trigger automatic supplier purchase here
-      // This would call the marketplace checkout endpoint to fulfill the order
+      // Report PROFIT (the margin) as the Google Ads conversion value — NOT the
+      // gross sale price — so Smart Bidding + our optimizer optimize net profit.
+      // Falls back to gross if the listing/margin can't be read.
+      let conversionValue = (session.amount_total || 0) / 100;
+      try {
+        const listing: any = await getListing(listingId);
+        const margin = Number(listing?.estimatedProfit);
+        if (Number.isFinite(margin) && margin > 0) conversionValue = margin;
+      } catch { /* keep gross fallback */ }
 
-      const html = generateSuccessPage(session);
+      const html = generateSuccessPage(session, conversionValue);
       res.setHeader('Content-Type', 'text/html');
       res.send(html);
     } else {
@@ -1374,7 +1381,7 @@ function generateProductLandingPage(listing: any): string {
 /**
  * Generate success page after payment
  */
-function generateSuccessPage(session: any): string {
+function generateSuccessPage(session: any, conversionValue?: number): string {
   return `
 <!DOCTYPE html>
 <html lang="en">
@@ -1383,7 +1390,7 @@ function generateSuccessPage(session: any): string {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Order Confirmed!</title>
     ${googleAdsGlobalTagHtml()}
-    ${googleAdsConversionEventHtml((session.amount_total || 0) / 100, session.id)}
+    ${googleAdsConversionEventHtml(conversionValue ?? (session.amount_total || 0) / 100, session.id)}
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body {

--- a/apps/api/src/services/google-ads/campaignOptimizer.test.ts
+++ b/apps/api/src/services/google-ads/campaignOptimizer.test.ts
@@ -38,8 +38,9 @@ describe('decideCampaignAction (autonomous brain)', () => {
     const d = decideCampaignAction({ ...base, spend: 50, conversions: 1, revenue: 20, dailyBudget: 20 });
     expect(d.action).toBe('reduce');
     expect(d.newBudget).toBe(14); // 20 * 0.7
+    // At min budget and still losing money => kill the chronic loser.
     const floored = decideCampaignAction({ ...base, spend: 50, conversions: 1, revenue: 20, dailyBudget: 5 });
-    expect(floored.action).toBe('hold');
+    expect(floored.action).toBe('pause');
   });
 
   it('holds a profitable-but-below-target campaign', () => {

--- a/apps/api/src/services/google-ads/campaignOptimizer.ts
+++ b/apps/api/src/services/google-ads/campaignOptimizer.ts
@@ -29,16 +29,21 @@ export interface OptimizationConfig {
   minDailyBudget: number;      // never reduce below this
 }
 
-export const DEFAULT_OPTIMIZATION_CONFIG: OptimizationConfig = {
-  targetRoas: 3.0,
-  minSpendToAct: 20,
-  zeroConvSpendCap: 30,
-  minConversionsToScale: 2,
-  scaleStep: 0.2,
-  reduceStep: 0.3,
-  maxDailyBudget: 200,
-  minDailyBudget: 5,
-};
+export const DEFAULT_OPTIMIZATION_CONFIG: OptimizationConfig = (() => {
+  const n = (k: string, d: number) => { const v = Number(process.env[k]); return Number.isFinite(v) && v > 0 ? v : d; };
+  return {
+    // Because conversion VALUE = profit, ROAS here means profit ÷ ad-spend.
+    // targetRoas 3.0 => only scale when profit is 3x the ad spend ("by miles").
+    targetRoas: n('OPTIMIZER_TARGET_ROAS', 3.0),
+    minSpendToAct: n('OPTIMIZER_MIN_SPEND', 20),
+    zeroConvSpendCap: n('OPTIMIZER_ZERO_CONV_CAP', 30),
+    minConversionsToScale: n('OPTIMIZER_MIN_CONV_SCALE', 2),
+    scaleStep: n('OPTIMIZER_SCALE_STEP', 0.2),
+    reduceStep: n('OPTIMIZER_REDUCE_STEP', 0.3),
+    maxDailyBudget: n('OPTIMIZER_MAX_BUDGET', 200),
+    minDailyBudget: n('OPTIMIZER_MIN_BUDGET', 5),
+  };
+})();
 
 export interface CampaignMetricsLike {
   status: string;
@@ -84,13 +89,14 @@ export function decideCampaignAction(c: CampaignMetricsLike, config: Optimizatio
     return { action: 'scale', reason: `ROAS ${round2(roas)}x >= ${config.targetRoas}x — scaling budget`, newBudget };
   }
 
-  // Losing money (ROAS below break-even) -> throttle budget (floored).
+  // Losing money (profit < ad spend) -> throttle; if already at min budget and
+  // STILL losing, kill it — a chronic loser should never keep draining spend.
   if (roas > 0 && roas < 1) {
     if (c.dailyBudget <= config.minDailyBudget) {
-      return { action: 'hold', reason: `underperformer already at min budget ($${config.minDailyBudget})` };
+      return { action: 'pause', reason: `ROAS ${round2(roas)}x < 1 at min budget — pausing chronic loser (profit never beat spend)` };
     }
     const newBudget = round2(Math.max(c.dailyBudget * (1 - config.reduceStep), config.minDailyBudget));
-    return { action: 'reduce', reason: `ROAS ${round2(roas)}x < 1 — reducing budget`, newBudget };
+    return { action: 'reduce', reason: `ROAS ${round2(roas)}x < 1 — profit below ad spend, reducing budget`, newBudget };
   }
 
   return { action: 'hold', reason: `holding (ROAS ${round2(roas)}x, ${c.conversions} conv)` };

--- a/apps/api/src/services/google-ads/stockSync.test.ts
+++ b/apps/api/src/services/google-ads/stockSync.test.ts
@@ -1,0 +1,71 @@
+const listCampaigns = jest.fn();
+const setCampaignStatus = jest.fn();
+const getListings = jest.fn();
+const updateListing = jest.fn();
+const validateProduct = jest.fn();
+
+jest.mock('./campaignAutomation', () => ({
+  listCampaigns: (...a: any[]) => listCampaigns(...a),
+  setCampaignStatus: (...a: any[]) => setCampaignStatus(...a),
+}));
+jest.mock('../../routes/marketplace', () => ({
+  getListings: (...a: any[]) => getListings(...a),
+  updateListing: (...a: any[]) => updateListing(...a),
+}));
+jest.mock('../productValidator', () => ({
+  productValidator: { validateProduct: (...a: any[]) => validateProduct(...a) },
+}));
+
+import { syncAdsToStock, campaignMatchesListing } from './stockSync';
+
+beforeEach(() => {
+  listCampaigns.mockReset(); setCampaignStatus.mockReset();
+  getListings.mockReset(); updateListing.mockReset(); validateProduct.mockReset();
+});
+
+describe('campaignMatchesListing', () => {
+  it('matches a campaign to its product by title', () => {
+    expect(campaignMatchesListing('Arbi - Wireless Earbuds Pro - US - 1712', 'Wireless Earbuds Pro')).toBe(true);
+    expect(campaignMatchesListing('Arbi - Some Other Thing - US', 'Wireless Earbuds Pro')).toBe(false);
+  });
+});
+
+describe('syncAdsToStock', () => {
+  it('pauses live campaigns for out-of-stock products and marks the listing', async () => {
+    listCampaigns.mockResolvedValue([
+      { id: 'c1', name: 'Arbi - Cool Necklace - US - 1', status: 'ENABLED' },
+      { id: 'c2', name: 'Arbi - Hot Watch - US - 2', status: 'ENABLED' },
+    ]);
+    getListings.mockResolvedValue([
+      { listingId: 'L1', productTitle: 'Cool Necklace', supplierPrice: 10, supplierUrl: 'x' },
+      { listingId: 'L2', productTitle: 'Hot Watch', supplierPrice: 20, supplierUrl: 'y' },
+    ]);
+    // Necklace OOS, Watch in stock.
+    validateProduct.mockImplementation(async (l: any) => ({ inStock: l.productTitle !== 'Cool Necklace' }));
+
+    const r = await syncAdsToStock();
+
+    expect(r.checked).toBe(2);
+    expect(r.outOfStock).toBe(1);
+    expect(setCampaignStatus).toHaveBeenCalledWith('c1', 'PAUSED', undefined);
+    expect(setCampaignStatus).not.toHaveBeenCalledWith('c2', 'PAUSED', undefined);
+    expect(updateListing).toHaveBeenCalledWith('L1', { status: 'out_of_stock' });
+  });
+
+  it('skips products with no live campaign (bounded API usage)', async () => {
+    listCampaigns.mockResolvedValue([{ id: 'c1', name: 'Arbi - Cool Necklace - US', status: 'PAUSED' }]);
+    getListings.mockResolvedValue([{ listingId: 'L1', productTitle: 'Cool Necklace', supplierPrice: 10 }]);
+    const r = await syncAdsToStock();
+    expect(r.checked).toBe(0);
+    expect(validateProduct).not.toHaveBeenCalled();
+  });
+
+  it('leaves campaigns running if stock cannot be verified', async () => {
+    listCampaigns.mockResolvedValue([{ id: 'c1', name: 'Arbi - Cool Necklace - US', status: 'ENABLED' }]);
+    getListings.mockResolvedValue([{ listingId: 'L1', productTitle: 'Cool Necklace', supplierPrice: 10 }]);
+    validateProduct.mockRejectedValue(new Error('timeout'));
+    const r = await syncAdsToStock();
+    expect(setCampaignStatus).not.toHaveBeenCalled();
+    expect(r.outOfStock).toBe(0);
+  });
+});

--- a/apps/api/src/services/google-ads/stockSync.ts
+++ b/apps/api/src/services/google-ads/stockSync.ts
@@ -1,0 +1,72 @@
+/**
+ * Stock-aware ad guard.
+ *
+ * Don't pay for ads on what you can't ship. This pauses the campaigns of any
+ * advertised product that has gone OUT OF STOCK at its supplier, and marks the
+ * listing so it stops being sold. It only checks products that actually have a
+ * LIVE campaign (bounded API usage), and only pauses — it never enables.
+ *
+ * Stock is verified via productValidator (Rainforest for Amazon-sourced items).
+ * CJ catalog items are treated as in-stock unless a check says otherwise.
+ */
+
+import { listCampaigns, setCampaignStatus } from './campaignAutomation';
+import { getListings, updateListing, MarketplaceListing } from '../../routes/marketplace';
+import { productValidator } from '../productValidator';
+
+/** Does this campaign belong to this listing? (campaign name = "Arbi - <title> - ...") */
+export function campaignMatchesListing(campaignName: string, productTitle: string): boolean {
+  const key = (productTitle || '').toLowerCase().replace(/[^a-z0-9\s]/g, '').trim().slice(0, 30);
+  return key.length > 3 && (campaignName || '').toLowerCase().includes(key);
+}
+
+export interface StockSyncResult {
+  checked: number;
+  outOfStock: number;
+  paused: { campaignId: string; name: string; listingId: string }[];
+}
+
+/**
+ * Pause ads for out-of-stock products. Returns what was paused.
+ */
+export async function syncAdsToStock(customerIdOverride?: string): Promise<StockSyncResult> {
+  const campaigns = (await listCampaigns(customerIdOverride)) as any[];
+  const liveEnabled = campaigns.filter((c) => c.status === 'ENABLED');
+  const listings = (await getListings('active')) as MarketplaceListing[];
+
+  const result: StockSyncResult = { checked: 0, outOfStock: 0, paused: [] };
+
+  for (const listing of listings) {
+    // Only spend a stock-check on products that are actually advertised live.
+    const matched = liveEnabled.filter((c) => campaignMatchesListing(c.name, listing.productTitle));
+    if (matched.length === 0) continue;
+
+    result.checked++;
+    let inStock = true;
+    try {
+      const v = await productValidator.validateProduct({
+        ...listing,
+        supplierUrl: (listing as any).supplierUrl,
+        supplierPrice: String(listing.supplierPrice),
+      });
+      inStock = v.inStock !== false;
+    } catch {
+      // If we can't verify, leave it running (don't pause on a transient error).
+      continue;
+    }
+
+    if (!inStock) {
+      result.outOfStock++;
+      for (const c of matched) {
+        try {
+          await setCampaignStatus(c.id, 'PAUSED', customerIdOverride);
+          result.paused.push({ campaignId: c.id, name: c.name, listingId: listing.listingId });
+        } catch { /* keep going */ }
+      }
+      // Stop selling what we can't ship.
+      try { await updateListing(listing.listingId, { status: 'out_of_stock' as any }); } catch { /* noop */ }
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
Brings main current with the gap-sealing work:
- Profit reported as conversion value (optimize net profit, not gross revenue)
- Optimizer kills chronic losers (profit < ad spend) + env-tunable thresholds
- Out-of-stock auto-pauses ads (don't pay for unfulfillable clicks)
- /status exposes autonomous/stock/amazon flags

Fast-forward, no conflicts.

https://claude.ai/code/session_01SRRsgGzQgvPFndtzKGpuu3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRRsgGzQgvPFndtzKGpuu3)_